### PR TITLE
Parse date inputs value to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ The `{{email-field}}` component can be passed the attribute `multiple`.
 * `{{time-field}}`
 * `{{week-field}}`
 
-All date/time fields can process `Date` objects, but will pass a `String` when
-updated.
+All date/time fields can process `Date` objects.
 
 All fields can be passed the `min`, `max` and `step` attributes.
 

--- a/addon/components/form-controls/date-input.js
+++ b/addon/components/form-controls/date-input.js
@@ -3,7 +3,7 @@ import NumberInputComponent from './number-input';
 
 import { toDateString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
 
 export default NumberInputComponent.extend({
   type: 'date',
@@ -17,5 +17,13 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'dateValue', value);
+  },
+
+  sanitizeInput(value) {
+    if (get(this, 'value') instanceof Date) {
+      return new Date(value);
+    } else {
+      return value;
+    }
   }
 });

--- a/addon/components/form-controls/datetime-input.js
+++ b/addon/components/form-controls/datetime-input.js
@@ -3,7 +3,7 @@ import NumberInputComponent from './number-input';
 
 import { toDatetimeString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
 
 export default NumberInputComponent.extend({
   type: 'datetime',
@@ -17,5 +17,13 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'datetimeValue', value);
+  },
+
+  sanitizeInput(value) {
+    if (get(this, 'value') instanceof Date) {
+      return new Date(value);
+    } else {
+      return value;
+    }
   }
 });

--- a/addon/components/form-controls/datetime-local-input.js
+++ b/addon/components/form-controls/datetime-local-input.js
@@ -3,7 +3,7 @@ import NumberInputComponent from './number-input';
 
 import { toDatetimeLocalString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
 
 export default NumberInputComponent.extend({
   type: 'datetime-local',
@@ -17,5 +17,13 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'datetimeValue', value);
+  },
+
+  sanitizeInput(value) {
+    if (get(this, 'value') instanceof Date) {
+      return new Date(value);
+    } else {
+      return value;
+    }
   }
 });

--- a/addon/components/form-controls/input.js
+++ b/addon/components/form-controls/input.js
@@ -17,11 +17,21 @@ const InputComponent = BaseInputComponent.extend({
   ],
 
   input() {
-    invokeAction(this, 'update', this.readDOMAttr('value'));
+    this._handleUpdate();
   },
 
   change() {
-    invokeAction(this, 'update', this.readDOMAttr('value'));
+    this._handleUpdate();
+  },
+
+  sanitizeInput(value) {
+    return value;
+  },
+
+  _handleUpdate() {
+    let value = this.readDOMAttr('value');
+    let sanitizedValue = this.sanitizeInput(value);
+    invokeAction(this, 'update', sanitizedValue);
   }
 });
 

--- a/addon/components/form-controls/month-input.js
+++ b/addon/components/form-controls/month-input.js
@@ -3,7 +3,7 @@ import NumberInputComponent from './number-input';
 
 import { toMonthString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
 
 export default NumberInputComponent.extend({
   type: 'month',
@@ -17,5 +17,13 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'dateValue', value);
+  },
+
+  sanitizeInput(value) {
+    if (get(this, 'value') instanceof Date) {
+      return new Date(value);
+    } else {
+      return value;
+    }
   }
 });

--- a/addon/components/form-controls/time-input.js
+++ b/addon/components/form-controls/time-input.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import NumberInputComponent from './number-input';
 
-import { toTimeString } from '../../utils/date-to-string';
+import { toTimeString, toDateString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
 
 export default NumberInputComponent.extend({
   type: 'time',
@@ -17,5 +17,14 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'timeValue', value);
+  },
+
+  sanitizeInput(value) {
+    let currentValue = get(this, 'value');
+    if (currentValue instanceof Date) {
+      return new Date(`${toDateString(currentValue)}T${value}`);
+    } else {
+      return value;
+    }
   }
 });

--- a/addon/components/form-controls/week-input.js
+++ b/addon/components/form-controls/week-input.js
@@ -3,7 +3,22 @@ import NumberInputComponent from './number-input';
 
 import { toWeekString } from '../../utils/date-to-string';
 
-const { set } = Ember;
+const { get, set } = Ember;
+
+const weekStringToDate = (string) => {
+  let [year, weekNr] = string.match(/^(\d{4})-W(\d{1,2})$/).slice(1);
+  let jan1OfYear = new Date(Number(year), 0, 1);
+  let jan1isWeek1 = jan1OfYear.getDay() < 4;
+  let correction  = new Date(Number(year), 0, 4).getDay() + 4;
+
+  if (!jan1isWeek1) {
+    correction += 7;
+  }
+
+  let offsetFrom1Jan = (Number(weekNr) * 7 + 1 - correction) * 8.64e7;
+
+  return new Date(+jan1OfYear + offsetFrom1Jan);
+};
 
 export default NumberInputComponent.extend({
   type: 'week',
@@ -17,5 +32,13 @@ export default NumberInputComponent.extend({
     }
 
     set(this, 'weekValue', value);
+  },
+
+  sanitizeInput(value) {
+    if (get(this, 'value') instanceof Date) {
+      return weekStringToDate(value);
+    } else {
+      return value;
+    }
   }
 });

--- a/tests/integration/components/form-controls/date-input-test.js
+++ b/tests/integration/components/form-controls/date-input-test.js
@@ -15,3 +15,18 @@ test('It accepts a date value', function(assert) {
   this.render(hbs`{{form-controls/date-input value=value}}`);
   assert.equal(this.$('input').val(), '2015-10-21', 'Date value is set');
 });
+
+test('Updating a date input that was set with a string', function(assert) {
+  this.set('value', '2015-10-22');
+  this.render(hbs`{{form-controls/date-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10-22').trigger('change');
+  assert.equal(this.get('value'), '2015-10-22');
+});
+
+test('Updating a date input that was set with a date', function(assert) {
+  this.set('value', new Date(2015, 9, 21));
+  this.render(hbs`{{form-controls/date-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10-22').trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date('2015-10-22')));
+});

--- a/tests/integration/components/form-controls/datetime-input-test.js
+++ b/tests/integration/components/form-controls/datetime-input-test.js
@@ -18,3 +18,18 @@ test('It accepts a date value', function(assert) {
   this.render(hbs`{{form-controls/datetime-input value=value}}`);
   assert.equal(this.$('input').val(), toDatetimeString(date), 'Datetime value is set');
 });
+
+test('Updating a date input that was set with a string', function(assert) {
+  this.set('value', toDatetimeString(new Date(2015, 9, 21, 16, 9)));
+  this.render(hbs`{{form-controls/datetime-input value=value update=(action (mut value))}}`);
+  this.$('input').val(toDatetimeString(new Date(2015, 9, 22, 16, 10))).trigger('change');
+  assert.equal(this.get('value'), toDatetimeString(new Date(2015, 9, 22, 16, 10)));
+});
+
+test('Updating a date input that was set with a date', function(assert) {
+  this.set('value', new Date(2015, 9, 21, 16, 9));
+  this.render(hbs`{{form-controls/datetime-input value=value update=(action (mut value))}}`);
+  this.$('input').val(toDatetimeString(new Date(2015, 9, 22, 16, 10))).trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date(2015, 9, 22, 16, 10)));
+});

--- a/tests/integration/components/form-controls/datetime-local-input-test.js
+++ b/tests/integration/components/form-controls/datetime-local-input-test.js
@@ -15,3 +15,18 @@ test('It accepts a date value', function(assert) {
   this.render(hbs`{{form-controls/datetime-local-input value=value}}`);
   assert.equal(this.$('input').val(), '2015-10-21T16:09', 'Date value is set');
 });
+
+test('Updating a date input that was set with a string', function(assert) {
+  this.set('value', '2015-10-21T16:09');
+  this.render(hbs`{{form-controls/datetime-local-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10-22T16:10').trigger('change');
+  assert.equal(this.get('value'), '2015-10-22T16:10');
+});
+
+test('Updating a date input that was set with a date', function(assert) {
+  this.set('value', new Date(2015, 9, 21, 16, 9));
+  this.render(hbs`{{form-controls/datetime-local-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10-22T16:10').trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date('2015-10-22T16:10')));
+});

--- a/tests/integration/components/form-controls/input-test.js
+++ b/tests/integration/components/form-controls/input-test.js
@@ -40,6 +40,14 @@ test('Changing the input value triggers the update action', function(assert) {
   assert.equal(this.get('value'), 'foo', 'Value is updated to \'foo\'');
 });
 
+test('It is possible to specify a sanitizeInput function', function(assert) {
+  this.on('sanitize', (value) => value.toUpperCase());
+  this.render(hbs`{{form-controls/input
+    sanitizeInput=(action 'sanitize') update=(action (mut value))}}`);
+  this.$('input').val('foo').trigger('change');
+  assert.equal(this.get('value'), 'FOO', 'Value was transformed to uppercase');
+});
+
 test(`It's possible to bind 'autosave'`, function(assert) {
   this.render(hbs`{{form-controls/input autosave='search'}}`);
   assert.equal(this.$('input').attr('autosave'), 'search', 'Attribute autosave is set');

--- a/tests/integration/components/form-controls/month-input-test.js
+++ b/tests/integration/components/form-controls/month-input-test.js
@@ -15,3 +15,18 @@ test('It accepts a date value', function(assert) {
   this.render(hbs`{{form-controls/month-input value=value}}`);
   assert.equal(this.$('input').val(), '2015-10', 'Month value is set');
 });
+
+test('Updating a date input that was set with a string', function(assert) {
+  this.set('value', '2015-10');
+  this.render(hbs`{{form-controls/month-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10').trigger('change');
+  assert.equal(this.get('value'), '2015-10');
+});
+
+test('Updating a date input that was set with a date', function(assert) {
+  this.set('value', new Date(2015, 9));
+  this.render(hbs`{{form-controls/month-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-10').trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date('2015-10')));
+});

--- a/tests/integration/components/form-controls/time-input-test.js
+++ b/tests/integration/components/form-controls/time-input-test.js
@@ -15,3 +15,18 @@ test('It accepts a time value', function(assert) {
   this.render(hbs`{{form-controls/time-input value=value}}`);
   assert.equal(this.$('input').val(), '16:09', 'Time value is set');
 });
+
+test('Updating a time input that was set with a string', function(assert) {
+  this.set('value', '16:09');
+  this.render(hbs`{{form-controls/time-input value=value update=(action (mut value))}}`);
+  this.$('input').val('16:10').trigger('change');
+  assert.equal(this.get('value'), '16:10');
+});
+
+test('Updating a time input that was set with a date', function(assert) {
+  this.set('value', new Date('2015-01-01T16:09'));
+  this.render(hbs`{{form-controls/time-input value=value update=(action (mut value))}}`);
+  this.$('input').val('16:10').trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date('2015-01-01T16:10')));
+});

--- a/tests/integration/components/form-controls/week-input-test.js
+++ b/tests/integration/components/form-controls/week-input-test.js
@@ -15,3 +15,18 @@ test('It accepts a date value', function(assert) {
   this.render(hbs`{{form-controls/week-input value=value}}`);
   assert.equal(this.$('input').val(), '2015-W43', 'Week value is set');
 });
+
+test('Updating a date input that was set with a string', function(assert) {
+  this.set('value', '2015-W43');
+  this.render(hbs`{{form-controls/week-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-W44').trigger('change');
+  assert.equal(this.get('value'), '2015-W44');
+});
+
+test('Updating a date input that was set with a date', function(assert) {
+  this.set('value', new Date(2015, 9, 21));
+  this.render(hbs`{{form-controls/week-input value=value update=(action (mut value))}}`);
+  this.$('input').val('2015-W44').trigger('change');
+  assert.ok(this.get('value') instanceof Date);
+  assert.equal(+this.get('value'), +(new Date(2015, 9, 26)));
+});


### PR DESCRIPTION
This commit adds support for parsing the changed text value of the `date`, `datetime`, `datetime-local`, `time`, `week` and `month` inputs to a `Date`. It will only do this when the supplied value was also a `Date`.