### PR TITLE
move ember-invoke-action to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-invoke-action": "1.2.0",
     "ember-suave": "1.2.3",
     "ember-try": "~0.0.8"
   },
@@ -42,7 +41,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1"
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-invoke-action": "1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
needs to be in dependencies instead of devDependencies to get installed correctly