### PR TITLE
A Couple of fixes

### DIFF
--- a/addon/components/form-controls/select.js
+++ b/addon/components/form-controls/select.js
@@ -103,7 +103,7 @@ const SelectComponent =  Ember.Component.extend({
   }),
 
   _selectedMultiple() {
-    let selectedValues = this.$().val();
+    let selectedValues = this.$().val() || [];
 
     return selectedValues.map((selectedValue) => {
       return this._findOption(selectedValue);

--- a/addon/components/form-controls/select.js
+++ b/addon/components/form-controls/select.js
@@ -28,7 +28,7 @@ const SelectComponent =  Ember.Component.extend({
     'multiple',
     'name',
     'required',
-    'required:aria-required',
+    'aria-required',
     'size',
     'tabindex',
     'title'
@@ -37,10 +37,8 @@ const SelectComponent =  Ember.Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    let required = this.getAttr('required');
-    if (required !== true) {
-      set(this, 'required', false);
-    }
+    let required = this.get('required');
+    set(this, 'aria-required', !!required);
 
     let options = this.getAttr('options');
     if (typeof options === 'string') {

--- a/addon/components/form-controls/textarea.js
+++ b/addon/components/form-controls/textarea.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
     'placeholder',
     'readonly',
     'required',
-    'required:aria-required',
+    'aria-required',
     'rows',
     'tabindex',
     'title',
@@ -34,10 +34,8 @@ export default Ember.Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    let required = this.getAttr('required');
-    if (required !== true) {
-      set(this, 'required', false);
-    }
+    let required = this.get('required');
+    set(this, 'aria-required', !!required);
   },
 
   input() {

--- a/tests/integration/components/form-controls/select-test.js
+++ b/tests/integration/components/form-controls/select-test.js
@@ -146,6 +146,30 @@ test('multiple select a value', function(assert) {
   assert.deepEqual(this.get('value'), [dubbel, ipa, saison]);
 });
 
+test('multiple select de-select all options', function(assert) {
+  let [dubbel, tripel, ipa, saison] = [
+    { id: 1, label: 'Dubbel', type: 'Trappist' },
+    { id: 2, label: 'Tripel', type: 'Trappist' },
+    { id: 3, label: 'IPA', type: 'IPA' },
+    { id: 4, label: 'Saison', type: 'Saison' }
+  ];
+
+  this.on('update', (value) => this.set('value', value));
+  this.set('value', [saison, ipa]);
+  this.set('options', [dubbel, tripel, ipa, saison]);
+
+  this.render(hbs`{{form-controls/select value=value options=options multiple=true
+      update=(action 'update') optionValuePath="id" optionLabelPath="label"
+      groupLabelPath="type"}}`);
+
+  this.$('select').val(['1', '3', '4']);
+  this.$('select').trigger('change');
+  this.$('select').val('');
+  this.$('select').trigger('change');
+
+  assert.deepEqual(this.get('value'), []);
+});
+
 test(`it's possible to bind 'size'`, function(assert) {
   this.render(hbs`{{form-controls/select size=5}}`);
   assert.equal(this.$('select').attr('size'), 5, 'attribute size is set');


### PR DESCRIPTION
When we deselect all the selected options, browsers set the value as an empty string rather than an empty array. Empty string creates an exception when the `map` function is [invoked](https://github.com/martndemus/ember-form-for/blob/master/addon/helpers/contains.js#L9) on it.  The second commit fixes that issue.

Update: Some tests fail unexpectedly in the ember canary version.