### PR TITLE
Add value as positional parameters to textarea form control.

### DIFF
--- a/addon/components/form-controls/textarea.js
+++ b/addon/components/form-controls/textarea.js
@@ -3,7 +3,7 @@ import { invokeAction } from 'ember-invoke-action';
 
 const { set } = Ember;
 
-export default Ember.Component.extend({
+const TextAreaComponent = Ember.Component.extend({
   tagName: 'textarea',
 
   attributeBindings: [
@@ -48,3 +48,9 @@ export default Ember.Component.extend({
     invokeAction(this, 'update', this.readDOMAttr('value'));
   }
 });
+
+TextAreaComponent.reopenClass({
+  positionalParams: ['value']
+});
+
+export default TextAreaComponent;


### PR DESCRIPTION
Hi there,
This PR fixes displaying initial value on the `textarea-field` - when `textarea-field` is rendered and model already has some value it's not displayed it. When `textarea-field` is changed to `text-field` then the value is displayed correctly - i.e.:

```
{{#form-for person as |f|}}
  {{f.textarea-field "description"}}

  {{f.submit "Save"}}
{{/form-for}}
```

I would love to add tests to covers that but I didn't find any existing tests that covers such case. Some guidance here would be helpful :).