### PR TITLE
Test against Ember Alpha

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,18 @@
 /*jshint node:true*/
 module.exports = {
-  useVersionCompatibility: true
+  useVersionCompatibility: true,
+  scenarios: [
+    {
+      name: 'ember-alpha',
+      allowedToFail: true,
+      bower: {
+        dependencies: {
+          "ember": "alpha"
+        },
+        resolutions: {
+          "ember": "alpha"
+        }
+      }
+    }
+  ]
 };


### PR DESCRIPTION
- Add ember-alpha to ember-try config.

There are two failing tests with Ember Alpha:

- [ ] `Integration | Component | form fields/radio field: It renders a label and a checkbox`
       (The `value` property seems to not be set correctly)
- [ ] `Integration | Component | form fields/select field: It renders a select box and label`
       (Render twice warning)