### PR TITLE
feat(DateField): parse empty string as remove date

### DIFF
--- a/addon/components/form-fields/date-field.js
+++ b/addon/components/form-fields/date-field.js
@@ -13,10 +13,10 @@ export default TextField.extend({
   },
 
   deserializeValue(value) {
-    if (value != null) {
-      return new Date(value);
+    if (value === '' || value === null) {
+      return null;
     }
 
-    return value;
+    return new Date(value);
   }
 });

--- a/addon/components/form-fields/date-field.js
+++ b/addon/components/form-fields/date-field.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import TextField from './text-field';
 import { toDateString } from '../../utils/date';
+
+const { isEmpty } = Ember;
 
 export default TextField.extend({
   control: 'one-way-date',
@@ -13,7 +16,7 @@ export default TextField.extend({
   },
 
   deserializeValue(value) {
-    if (value === '' || value === null) {
+    if (isEmpty(value)) {
       return null;
     }
 

--- a/tests/integration/components/form-fields/date-field-test.js
+++ b/tests/integration/components/form-fields/date-field-test.js
@@ -25,3 +25,9 @@ test('Updating a date input', function(assert) {
   assert.ok(this.get('object.date') instanceof Date);
   assert.equal(+this.get('object.date'), +(new Date('2015-10-22')));
 });
+
+test('Can remove from date input', function(assert) {
+  this.render(hbs`{{form-fields/date-field propertyName object=object}}`);
+  this.$('input').val('').trigger('change');
+  assert.equal(this.get('object.date'), null);
+});


### PR DESCRIPTION
on Chrome, the date field gets an empty string as a value when the clear button is clicked. Since it is `value != null` its parsed as a date, which is an `Invalid Date`, which is a Date object. It results in an error. It should recognise the empty string value, as well as null, as a desire to set to null.