### PR TITLE
Include missing promptText option

### DIFF
--- a/addon/templates/components/form-fields/select-field.hbs
+++ b/addon/templates/components/form-fields/select-field.hbs
@@ -20,6 +20,7 @@
       groupLabelPath=groupLabelPath
       hidden=hidden
       includeBlank=includeBlank
+      promptText=promptText
       lang=lang
       multiple=multiple
       options=options


### PR DESCRIPTION
The control has includeBlank and promptText, but I do not believe it works properly without this.