### PR TITLE
makes checkbox element layout customizable

### DIFF
--- a/addon/templates/components/form-fields/checkbox-field.hbs
+++ b/addon/templates/components/form-fields/checkbox-field.hbs
@@ -11,23 +11,29 @@
     label=label
     control=control
     update=(action update) as |f|}}
-  {{#f.label required=required}}
-    {{f.control
-        accesskey=accesskey
-        autocomplete=autocomplete
-        autofocus=autofocus
-        autosave=autosave
-        dir=dir
-        disabled=disabled
-        hidden=hidden
-        lang=lang
-        list=list
-        required=required
-        tabindex=tabindex
-        title=title
-    }}
-    {{f.labelText}}
-  {{/f.label}}
-  {{f.errors}}
-  {{f.hint}}
+  {{#if component}}
+    {{component component f=f}}
+  {{else if hasBlock}}
+    {{yield f}}
+  {{else}}
+    {{#f.label required=required}}
+      {{f.control
+          accesskey=accesskey
+          autocomplete=autocomplete
+          autofocus=autofocus
+          autosave=autosave
+          dir=dir
+          disabled=disabled
+          hidden=hidden
+          lang=lang
+          list=list
+          required=required
+          tabindex=tabindex
+          title=title
+      }}
+      {{f.labelText}}
+    {{/f.label}}
+    {{f.errors}}
+    {{f.hint}}
+  {{/if}}
 {{/form-field}}


### PR DESCRIPTION
I have a use case where I need to use a css library to style the checkbox, and all I need to get it working is change the layout of the control and label elements.

This uses the same customization overrides as `custom-field`.
