### PR TITLE
Fix ARIA violation when there are no hints or errors

### DIFF
--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -16,7 +16,8 @@ const {
   observer,
   set,
   Component,
-  String: { dasherize }
+  String: { dasherize },
+  isEmpty
 } = Ember;
 
 const FormFieldComponent = Component.extend({
@@ -134,7 +135,7 @@ const FormFieldComponent = Component.extend({
       });
     }
 
-    return ids.join(' ');
+    return isEmpty(ids) ? null : ids.join(' ');
   }),
 
   _nameForObject() {

--- a/tests/integration/components/form-field-test.js
+++ b/tests/integration/components/form-field-test.js
@@ -281,6 +281,15 @@ test('It sets the describedBy of the control to the id of the hint', function(as
   assert.equal(this.$('input').attr('aria-describedby'), expectedId);
 });
 
+test('It does not set the describedBy of the control when there are no ids', function(assert) {
+  this.render(hbs`
+    {{#form-field "givenName" id="test123" object=object as |f|}}
+      {{f.control}}
+    {{/form-field}}
+  `);
+  assert.equal(this.$('input').attr('aria-describedby'), null);
+});
+
 test('It passes invalid to the control when errors are present', function(assert) {
   this.set('object.errors', { givenName: [{ message: 'can\'t be blank' }] });
 


### PR DESCRIPTION
Currently, the `aria-describedby` attribute can end up as an empty string when there are no hints or errors on the field. This causes exceptions to be raised by tools like `ember-a11y-testing` because an empty string on the attribute is apparently a violation of ARIA rules.

PR simply checks the `ids` array at the end of the CP for `describedByValue` and returns null if it's empty, otherwise continues with existing code.

Pic of ARIA violation:
![](https://i.imgur.com/SbjS9ED.png)