### PR TITLE
Update configuration to accept errorsPath rather than simply errorsProperty

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ the following thing in your `config/environment.js` file:
 module.exports = function(environment) {
   var ENV = {
     'ember-form-for': {
-      'errorsProperty': 'error'
+      errorsPath: 'error.PROPERTY_NAME.validation',
     }
   };
 
@@ -279,5 +279,8 @@ module.exports = function(environment) {
 };
 ```
 
-This is because ember-changeset stores it's errors on the `error` property,
+This is because ember-changeset stores it's errors on the `error.PROPERTY_NAME.validation` property,
 while Ember Form For expects them (by default) to be on the `errors` property.
+
+For those still using the old configuration of setting `errorsPath`, this method will still work. 
+However, if both are defined then `errorsPath` will take precedence.

--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -29,6 +29,17 @@ const FormFieldComponent = Component.extend({
   _defaultErrorsProperty: 'errors',
   errorsProperty: or('config.errorsProperty', '_defaultErrorsProperty'),
 
+  errorsPath(propertyName) {
+    let errorsPath = this.get('config.errorsPath');
+    let errorsProperty = this.get('errorsProperty');
+
+    if (!isPresent(errorsPath)) {
+      errorsPath = `${errorsProperty}.PROPERTY_NAME`;
+    }
+
+    return errorsPath.replace('PROPERTY_NAME', propertyName);
+  },
+
   classNameBindings: [],
 
   concatenatedProperties: [
@@ -75,12 +86,12 @@ const FormFieldComponent = Component.extend({
 
   propertyNameDidChange: observer('propertyName', 'errorsProperty', function() {
     let propertyName = get(this, 'propertyName');
-    let errorsProperty = get(this, 'errorsProperty');
+    let errorsPath = `object.${this.errorsPath(propertyName)}`;
 
     mixin(this, {
       rawValue: reads(`object.${propertyName}`),
-      errors: reads(`object.${errorsProperty}.${propertyName}`),
-      hasErrors: notEmpty(`object.${errorsProperty}.${propertyName}`)
+      errors: reads(errorsPath),
+      hasErrors: notEmpty(errorsPath)
     });
   }),
 

--- a/tests/integration/components/form-field-test.js
+++ b/tests/integration/components/form-field-test.js
@@ -168,6 +168,67 @@ test('It can display errors', function(assert) {
   assert.ok(this.$().text().trim().indexOf('can\'t be blank') !== -1);
 });
 
+test('Displays errors at the correct errorsPath', function(assert) {
+  this.set('object.error', {
+    givenName: {
+      validation: [
+        {
+          message: 'pizza'
+        }
+      ]
+    }
+  });
+  this.set('config', { errorsPath: 'error.PROPERTY_NAME.validation' });
+
+  this.render(hbs`
+    {{#form-field "givenName" object=object form="form123" config=config as |f|}}
+      {{f.errors}}
+    {{/form-field}}
+  `);
+
+  assert.ok(this.$().text().trim().indexOf('pizza') !== -1);
+});
+
+test('Still respects errorsProperty if no errorsPath is defined', function(assert) {
+  this.set('object.foo', {
+    givenName: [
+      {
+        message: 'pizza'
+      }
+    ]
+  });
+  this.set('config', { errorsProperty: 'foo' });
+
+  this.render(hbs`
+    {{#form-field "givenName" object=object form="form123" config=config as |f|}}
+      {{f.errors}}
+    {{/form-field}}
+  `);
+
+  assert.ok(this.$().text().trim().indexOf('pizza') !== -1);
+});
+
+test('errorsPath takes priority over errorsProperty', function(assert) {
+  this.set('object.foo', {
+    givenName: {
+      validation: [
+        {
+          message: 'pizza'
+        }
+      ]
+    }
+  });
+  this.set('config', { errorsProperty: 'foo', errorsPath: 'foo.PROPERTY_NAME.validation' });
+
+  this.render(hbs`
+    {{#form-field "givenName" object=object form="form123" config=config as |f|}}
+      {{f.errors}}
+    {{/form-field}}
+  `);
+
+  assert.ok(this.$().text().trim().indexOf('pizza') !== -1);
+});
+
 test('It exposes hasErrors', function(assert) {
   this.set('object.errors', { givenName: [{ message: 'can\'t be blank' }] });
 


### PR DESCRIPTION
- Add support for errorsPath as somewhat of a template string
- Backwards compatible with errorsProperty
- Update to README to include changes
- This fixes #113 