### PR TITLE
Removes deprecation warning of using contains

### DIFF
--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -4,7 +4,7 @@ const { isArray } = Ember;
 
 export function contains([haystack, needle]) {
   if (isArray(haystack)) {
-    return Ember.A(haystack).contains(needle);
+    return Ember.A(haystack).includes(needle);
   } else {
     return haystack === needle;
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-invoke-action": "1.3.1",
-    "ember-one-way-controls": "1.1.0"
+    "ember-one-way-controls": "1.1.0",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Fixes deprecation warning [EMBER-RUNTIME.ENUMERABLE-CONTAINS](http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains) which is introduced in Ember 2.8. A polyfill module has been added in the dependency, as instructed in the deprecation page, to fix it in a backward compatible way.