### PR TITLE
feat(field): Use async-button to handle promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ update the property on the object with the new value.
 
 This action is called when a submit button is clicked. It will pass the object
 as first argument. By default it will call the `save` function on the object.
+This action also supports returning a promise, which the `{{f.submit}}` component,
+which uses [ember-async-button], will handle to show different states.
 
 #### reset
 
@@ -182,7 +184,7 @@ Additionally these buttons are also available:
 
  - button
  - reset
- - submit
+ - submit (uses [ember-async-button] so supports those options as well).
 
 ## form-fields
 
@@ -284,3 +286,5 @@ while Ember Form For expects them (by default) to be on the `errors` property.
 
 For those still using the old configuration of setting `errorsProperty`, this method will still work. 
 However, if both are defined then `errorsPath` will take precedence.
+
+[ember-async-button]: https://github.com/DockYard/ember-async-button

--- a/addon/components/form-controls/submit.js
+++ b/addon/components/form-controls/submit.js
@@ -1,11 +1,34 @@
-import ButtonComponent from './button';
-import { invokeAction } from 'ember-invoke-action';
+import Ember from 'ember';
+import AsyncButton from 'ember-async-button/components/async-button';
+import layout from 'ember-async-button/templates/components/async-button';
+import DynamicAttributeBindings from 'ember-one-way-controls/-private/dynamic-attribute-bindings';
 
-export default ButtonComponent.extend({
-  type: 'submit',
+const { get, set, inject: { service }, computed: { alias } } = Ember;
 
-  click(e) {
-    e.preventDefault();
-    invokeAction(this, 'submit', ...arguments);
+const SubmitButton = AsyncButton.extend(DynamicAttributeBindings, {
+  layout,
+
+  config: service('ember-form-for/config'),
+  submit: alias('action'),
+  default: 'Submit',
+  pending: 'Submitting...',
+
+  NON_ATTRIBUTE_BOUND_PROPS: [
+    'click'
+  ],
+
+  init() {
+    this._super(...arguments);
+
+    let type = get(this, 'type');
+    let buttonClasses = get(this, `config.${type}Classes`);
+    let classNames = get(this, 'classNames');
+    set(this, 'classNames', (classNames || []).concat(buttonClasses));
   }
 });
+
+SubmitButton.reopenClass({
+  positionalParams: ['default']
+});
+
+export default SubmitButton;

--- a/addon/templates/components/form-for.hbs
+++ b/addon/templates/components/form-for.hbs
@@ -26,7 +26,7 @@
     custom-field=(component 'form-fields/custom-field' object=object update=update)
 
     reset=(component 'form-controls/reset' reset=(action reset object))
-    submit=(component 'form-controls/submit' submit=(action "submit" object))
+    submit=(component 'form-controls/submit' action=(action "submit" object))
 
     button=(component 'form-controls/button')
     ) as |formFields|}}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-async-button": "1.0.2",
     "ember-cli": "^2.7.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.1",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { set, isEmpty } = Ember;
+const { set, run, RSVP, isEmpty } = Ember;
 
 function createEmptyObject(attrs) {
   return Ember.Object.create(attrs, {
@@ -14,8 +14,12 @@ function blankUser() {
 
 export default Ember.Controller.extend({
   submit() {
-    window.alert('Saved!');
-    window.location.reload();
+    return new RSVP.Promise((resolve) => {
+      run.later(this, () => {
+        window.alert('Saved!');
+        resolve();
+      }, 1500);
+    });
   },
 
   reset() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,7 +22,7 @@
   {{f.checkbox-field "terms" label="I agree to the Terms of Service" required=true}}
 
   {{f.reset  "Clear form"}}
-  {{f.submit "Create account"}}
+  {{f.submit "Create account" pending='Creating..'}}
 {{/form-for}}
 
 {{outlet}}


### PR DESCRIPTION
Allows the user to pass back a promise in the submit action
which affects the state of the submit button which now uses
[ember-async-button](https://github.com/DockYard/ember-async-button).