### PR TITLE
[Fix] better error presence check in handleErrors

### DIFF
--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -6,6 +6,7 @@ const {
   get,
   inject: { service },
   isPresent,
+  isArray,
   run: { schedule },
   set
 } = Ember;
@@ -37,15 +38,22 @@ const FormForComponent = Component.extend({
   },
 
   handleErrors(object) {
+    if (this.hasErrors(object)) {
+      set(this, 'tabindex', -1);
+      schedule('afterRender', () => this.$().focus());
+    }
+  },
+
+  hasErrors(object) {
     let errors = get(object, 'errors');
 
-    if (errors) {
-      for (let propertyName in errors) {
-        if (isPresent(get(errors, propertyName))) {
-          set(this, 'tabindex', -1);
-          schedule('afterRender', () => this.$().focus());
-          break;
-        }
+    return isPresent(errors) && (isArray(errors) || this.hasErrorAsObject(errors));
+  },
+
+  hasErrorAsObject(errors) {
+    for (let property in errors) {
+      if (errors.hasOwnProperty(property) && isPresent(get(errors, property))) {
+        return true;
       }
     }
   },

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -156,7 +156,7 @@ test('Reset calls object#rollback by default', function(assert) {
   this.$('button[type="reset"]').click();
 });
 
-test('Form is focused when submit action is triggered and object contains errors', function(assert) {
+test('Form is focused when submit action is triggered and object contains error object containing errors', function(assert) {
   this.set('object', {
     save: () => undefined,
     errors: {
@@ -172,6 +172,56 @@ test('Form is focused when submit action is triggered and object contains errors
 
   run(() => this.$('button[type="submit"]').click());
   assert.equal(document.activeElement, this.$('form').get(0));
+});
+
+test('Form is not focused when submit action is triggered and object contains empty error object', function(assert) {
+  this.set('object', {
+    save: () => undefined,
+    errors: {}
+  });
+
+  this.render(hbs`
+    {{#form-for object as |f|}}
+      {{f.submit}}
+    {{/form-for}}
+  `);
+
+  run(() => this.$('button[type="submit"]').click());
+  assert.notEqual(document.activeElement, this.$('form').get(0));
+});
+
+test('Form is focused when submit action is triggered and object contains errors as array', function(assert) {
+  this.set('object', {
+    save: () => undefined,
+    errors: [
+      { attr: 'foo', message: ['error'] }
+    ]
+  });
+
+  this.render(hbs`
+    {{#form-for object as |f|}}
+      {{f.submit}}
+    {{/form-for}}
+  `);
+
+  run(() => this.$('button[type="submit"]').click());
+  assert.equal(document.activeElement, this.$('form').get(0));
+});
+
+test('Form is not focused when submit action is triggered and object contains errors as empty array', function(assert) {
+  this.set('object', {
+    save: () => undefined,
+    errors: []
+  });
+
+  this.render(hbs`
+    {{#form-for object as |f|}}
+      {{f.submit}}
+    {{/form-for}}
+  `);
+
+  run(() => this.$('button[type="submit"]').click());
+  assert.notEqual(document.activeElement, this.$('form').get(0));
 });
 
 test('I can set and configure custom formClasses', function(assert) {


### PR DESCRIPTION
Currently `ember-form-for` assumes error as an object. But `ember-changeset-validations` returns error has an array. This PR changes `handleErrors` function so that it checks for both. Some tests have also been added to check those edge conditions.

Fixes #139 when using `ember-changeset-validations`.