### PR TITLE
Prevent DOM update after destroy

### DIFF
--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -43,7 +43,12 @@ const FormForComponent = Component.extend({
       for (let propertyName in errors) {
         if (isPresent(get(errors, propertyName))) {
           set(this, 'tabindex', -1);
-          schedule('afterRender', () => this.$().focus());
+          schedule('afterRender', () => {
+            if (this.isDestroyed || this.isDestroying) {
+              return;
+            }
+            this.$().focus();
+          });
           break;
         }
       }


### PR DESCRIPTION
Could also just check `this.$()`, but feel like this is more future proof if you add more code later.