### PR TITLE
Ember changeset doesn't play nice with the i18n integration.

### DIFF
--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -82,7 +82,7 @@ const FormFieldComponent = Component.extend({
     assert('{{form-field}} requires the propertyName property to be set',
            typeof get(this, 'propertyName') === 'string');
 
-    set(this, 'modelName', getWithDefault(this, 'object.modelName', get(this, 'object.constructor.modelName')));
+    set(this, 'modelName', this.getModelName());
   },
 
   propertyNameDidChange: observer('propertyName', 'errorsProperty', function() {
@@ -153,6 +153,15 @@ const FormFieldComponent = Component.extend({
   _nameForObject() {
     return get(this, 'modelName')
         || guidFor(get(this, 'object'));
+  },
+
+  getModelName() {
+    let name = getWithDefault(this, 'object.modelName', get(this, 'object.constructor.modelName'));
+    if (name) {
+      return name;
+    } else {
+      return get(this, 'object._content.constructor.modelName');
+    }
   },
 
   value: computed('rawValue', function() {

--- a/tests/integration/components/form-field-test.js
+++ b/tests/integration/components/form-field-test.js
@@ -52,6 +52,26 @@ test('If the i18n service is available, compute the label from there', function(
   assert.equal(this.$('label').text().trim(), 'Your name');
 });
 
+test('If the i18n service is available, and changeset has been used, compute the label from there', function(assert) {
+  assert.expect(2);
+  this.registry.register('service:i18n', EmberObject.extend({
+    t(key) {
+      assert.equal(key, 'given-name');
+      return 'Your name';
+    }
+  }));
+
+  this.set('changeset', {
+    _content: this.get('object')
+  });
+
+  this.render(hbs`
+    {{#form-field "givenName" object=changeset as |f|}}{{f.label}}{{/form-field}}
+  `);
+
+  assert.equal(this.$('label').text().trim(), 'Your name');
+});
+
 test('When modelName is present, use it for i18n labels', function(assert) {
   assert.expect(2);
   this.registry.register('service:i18n', EmberObject.extend({


### PR DESCRIPTION
As far as I can see, the translation system breaks as the changeset does not provide 'modelName'.

This results in translation keys similar to:

`prefix.firstName` as opposed to `prefix.contact.firstName`