### PR TITLE
Add automated translations to hints and placeholders

### DIFF
--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/form-field';
 
-import { humanize } from '../utils/strings';
+import TranslatedInput from '../mixins/translated-input';
 
 const {
   Component,
@@ -20,10 +20,9 @@ const {
   set
 } = Ember;
 
-const FormFieldComponent = Component.extend({
+const FormFieldComponent = Component.extend(TranslatedInput, {
   layout,
 
-  i18n: service(),
   config: service('ember-form-for/config'),
 
   _defaultErrorsProperty: 'errors',
@@ -99,28 +98,6 @@ const FormFieldComponent = Component.extend({
   update(object, propertyName, value) {
     set(object, propertyName, value);
   },
-
-  labelText: computed('propertyName', 'label', function() {
-    let i18n = get(this, 'i18n');
-    let label = get(this, 'label');
-
-    if (isPresent(label)) {
-      return label;
-    } else if (isPresent(i18n)) {
-      return i18n.t(get(this, 'labelI18nKey'));
-    } else {
-      return humanize(get(this, 'propertyName'));
-    }
-  }),
-
-  labelI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', function() {
-    return [
-      get(this, 'config.i18nKeyPrefix'),
-      dasherize(get(this, 'modelName') || ''),
-      dasherize(get(this, 'propertyName') || '')
-    ].filter((x) => !!x)
-     .join('.');
-  }),
 
   fieldId: computed('object', 'form', 'propertyName', function() {
     let baseId = get(this, 'form') || get(this, 'elementId');

--- a/addon/components/form-fields/checkbox-group/option.js
+++ b/addon/components/form-fields/checkbox-group/option.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../../../templates/components/form-fields/checkbox-group/option';
 
-import { humanize } from '../../../utils/strings';
+import TranslatedInput from '../../mixins/translated-input';
 
 const {
   Component,
@@ -13,7 +13,7 @@ const {
   isPresent
 } = Ember;
 
-export default Component.extend({
+export default Component.extend(TranslatedInput, {
   tagName: '',
   layout,
 
@@ -21,33 +21,4 @@ export default Component.extend({
   config: service('ember-form-for/config'),
 
   modelName: or('object.modelName', 'object.constructor.modelName'),
-
-  labelText: computed('value', 'label', 'labelI18nKey', function() {
-    let i18n = get(this, 'i18n');
-    let label = get(this, 'label');
-
-    if (isPresent(label)) {
-      return label;
-    } else if (isPresent(i18n)) {
-      return i18n.t(get(this, 'labelI18nKey'));
-    } else {
-      return get(this, 'label') || humanize(get(this, 'value'));
-    }
-  }),
-
-  labelI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', 'value', function() {
-    let value = get(this, 'value');
-
-    if (isPresent(value)) {
-      value = dasherize(value.toString());
-    }
-
-    return [
-      get(this, 'config.i18nKeyPrefix'),
-      dasherize(get(this, 'modelName') || ''),
-      dasherize(get(this, 'propertyName') || ''),
-      value
-    ].filter((x) => !!x)
-     .join('.');
-  })
 });

--- a/addon/components/form-fields/radio-field.js
+++ b/addon/components/form-fields/radio-field.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../../templates/components/form-fields/radio-field';
 
-import { humanize } from '../../utils/strings';
+import TranslatedInput from '../../mixins/translated-input';
 
 const {
   Component,
@@ -14,7 +14,7 @@ const {
   set
 } = Ember;
 
-const RadioFieldComponent = Component.extend({
+const RadioFieldComponent = Component.extend(TranslatedInput, {
   tagName: '',
   layout,
 
@@ -28,35 +28,6 @@ const RadioFieldComponent = Component.extend({
   update(object, propertyName, value) {
     set(object, propertyName, value);
   },
-
-  labelText: computed('value', 'label', function() {
-    let i18n = get(this, 'i18n');
-    let label = get(this, 'label');
-
-    if (isPresent(label)) {
-      return label;
-    } else if (isPresent(i18n)) {
-      return i18n.t(get(this, 'labelI18nKey'));
-    } else {
-      return get(this, 'label') || humanize(get(this, 'value'));
-    }
-  }),
-
-  labelI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', 'value', function() {
-    let value = get(this, 'value');
-
-    if (isPresent(value)) {
-      value = dasherize(value.toString());
-    }
-
-    return [
-      get(this, 'config.i18nKeyPrefix'),
-      dasherize(get(this, 'modelName') || ''),
-      dasherize(get(this, 'propertyName') || ''),
-      value
-    ].filter((x) => !!x)
-     .join('.');
-  })
 });
 
 RadioFieldComponent.reopenClass({

--- a/addon/mixins/translated-input.js
+++ b/addon/mixins/translated-input.js
@@ -1,0 +1,73 @@
+import Ember from 'ember';
+import { humanize } from '../utils/strings';
+
+const {
+  String: { dasherize },
+  computed,
+  isPresent,
+  get
+} = Ember;
+
+export default Ember.Mixin.create({
+  i18n: Ember.inject.service(),
+
+  labelText: computed('propertyName', 'label', function() {
+    let i18n = get(this, 'i18n');
+    let text = get(this, 'label');
+    let key  = get(this, 'labelI18nKey');
+
+    if (isPresent(text)) {
+      return text;
+    } else if (isPresent(i18n) && i18n.exists(key)) {
+      return i18n.t(key);
+    } else {
+      return humanize(get(this, 'propertyName'));
+    }
+  }),
+
+  hintText: computed('propertyName', 'hint', function() {
+    let i18n = get(this, 'i18n');
+    let text = get(this, 'hint');
+    let key  = get(this, 'hintI18nKey');
+
+    if (isPresent(text)) {
+      return text;
+    } else if (isPresent(i18n) && i18n.exists(key)) {
+      return i18n.t(key);
+    }
+  }),
+
+  placeholderText: computed('propertyName', 'placeholder', function() {
+    let i18n = get(this, 'i18n');
+    let text = get(this, 'placeholder');
+    let key  = get(this, 'placeholderI18nKey');
+
+    if (isPresent(text)) {
+      return text;
+    } else if (isPresent(i18n) && i18n.exists(key)) {
+      return i18n.t(key);
+    }
+  }),
+
+  labelI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', function() {
+    return this.generateI18nKey();
+  }),
+
+  hintI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', function() {
+    return this.generateI18nKey('hints');
+  }),
+
+  placeholderI18nKey: computed('config.i18nKeyPrefix', 'modelName', 'propertyName', function() {
+    return this.generateI18nKey('placeholders');
+  }),
+
+  generateI18nKey(type) {
+    return [
+      get(this, 'config.i18nKeyPrefix'),
+      type,
+      dasherize(get(this, 'modelName') || ''),
+      dasherize(get(this, 'propertyName') || '')
+    ].filter((x) => !!x)
+     .join('.');
+  },
+});

--- a/addon/templates/components/form-field.hbs
+++ b/addon/templates/components/form-field.hbs
@@ -9,9 +9,10 @@
       errorId=(concat fieldId "_error")
       errors=errors
       errorClasses=errorClasses)
+  hintText=hintText
   hasErrors=hasErrors
   hint=(component 'form-hint'
-      hint=hint
+      hint=hintText
       hintClasses=hintClasses
       hintId=(concat fieldId "_hint"))
   control=(component control value

--- a/tests/integration/components/form-field-test.js
+++ b/tests/integration/components/form-field-test.js
@@ -329,7 +329,7 @@ test('It can yield the labelText', function(assert) {
 test('It can yield a hint', function(assert) {
   this.render(hbs`
     {{#form-field "givenName" object=object hint="This is a hint" as |f|}}
-      {{f.hint}}
+      {{f.hintText}}
     {{/form-field}}
   `);
   assert.equal(this.$('span').text().trim(), 'This is a hint');


### PR DESCRIPTION
Usage:

`prefix.modelName.hints.propertyName` and `prefix.modelName.placeholders.propertyName` will now be automatically picked up by ember-form-for.

Pros:
- Dries up the translation code into a shared mixin
- Only uses the translation if it exists, otherwise it defaults to the humanized name

Cons: 
- Exposes some translation code that some of the recipients don't use
  - Radio groups and checkbox options don't use hints or placeholders 

Further query:

The README implies that the translations are camelized (https://github.com/martndemus/ember-form-for#i18n), but this code seems to use dasherized attributeNames. 
Am I missing something in my refactor? If not, happy to open a new PR to either update the README or the code.