### PR TITLE
Only inject i18n if it is in the project

### DIFF
--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -23,7 +23,6 @@ const {
 const FormFieldComponent = Component.extend({
   layout,
 
-  i18n: service(),
   config: service('ember-form-for/config'),
 
   _defaultErrorsProperty: 'errors',

--- a/addon/components/form-fields/checkbox-group/option.js
+++ b/addon/components/form-fields/checkbox-group/option.js
@@ -17,7 +17,6 @@ export default Component.extend({
   tagName: '',
   layout,
 
-  i18n: service(),
   config: service('ember-form-for/config'),
 
   modelName: or('object.modelName', 'object.constructor.modelName'),

--- a/addon/components/form-fields/radio-field.js
+++ b/addon/components/form-fields/radio-field.js
@@ -20,7 +20,6 @@ const RadioFieldComponent = Component.extend({
 
   control: 'one-way-radio',
 
-  i18n: service(),
   config: service('ember-form-for/config'),
 
   modelName: or('object.modelName', 'object.constructor.modelName'),

--- a/app/initializers/ember-form-for-i18n.js
+++ b/app/initializers/ember-form-for-i18n.js
@@ -1,0 +1,12 @@
+export function initialize(app) {
+  let i18n = app.__container__.lookup('service:i18n');
+  if (i18n) {
+    app.inject('component', 'i18n', 'service:i18n');
+  }
+}
+
+export default {
+  name: 'i18n',
+  initialize: initialize,
+};
+


### PR DESCRIPTION
This is a more heavy handed approach as it injects i18n into *all* components, but it should allow for those users who don't use any sort of i18n library.