### PR TITLE
Select field was missing from the list of default form controls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The default form controls are:
  - radio-group
  - range-field
  - search-field
+ - select-field
  - tel-field
  - text-field
  - textarea-field


### PR DESCRIPTION
Noticed that the example used `select-field`, but it was not included in the list of default form controls.