### PR TITLE
Watch i18n service for locale change and update labels

### DIFF
--- a/addon/components/form-field.js
+++ b/addon/components/form-field.js
@@ -100,7 +100,7 @@ const FormFieldComponent = Component.extend({
     set(object, propertyName, value);
   },
 
-  labelText: computed('propertyName', 'label', function() {
+  labelText: computed('propertyName', 'label', 'i18n.locale', function() {
     let i18n = get(this, 'i18n');
     let label = get(this, 'label');
 

--- a/addon/components/form-fields/checkbox-group/option.js
+++ b/addon/components/form-fields/checkbox-group/option.js
@@ -22,7 +22,7 @@ export default Component.extend({
 
   modelName: or('object.modelName', 'object.constructor.modelName'),
 
-  labelText: computed('value', 'label', 'labelI18nKey', function() {
+  labelText: computed('value', 'label', 'labelI18nKey', 'i18n.locale', function() {
     let i18n = get(this, 'i18n');
     let label = get(this, 'label');
 

--- a/addon/components/form-fields/radio-field.js
+++ b/addon/components/form-fields/radio-field.js
@@ -29,7 +29,7 @@ const RadioFieldComponent = Component.extend({
     set(object, propertyName, value);
   },
 
-  labelText: computed('value', 'label', function() {
+  labelText: computed('value', 'label', 'i18n.locale', function() {
     let i18n = get(this, 'i18n');
     let label = get(this, 'label');
 


### PR DESCRIPTION
When switching locale, `label_text` was not recomputed, because it was not aware of the locale. I added `i18n.locale` to the watch list. 