### PR TITLE
Add support for focusIn (and other actions)

### DIFF
--- a/addon/templates/components/form-fields/checkbox-field.hbs
+++ b/addon/templates/components/form-fields/checkbox-field.hbs
@@ -10,6 +10,7 @@
     hint=hint
     label=label
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{#f.label required=required}}
     {{f.control

--- a/addon/templates/components/form-fields/checkbox-group.hbs
+++ b/addon/templates/components/form-fields/checkbox-group.hbs
@@ -19,6 +19,7 @@
           object=object
           propertyName=propertyName
           option=option
+          focusIn=fieldFocusIn
           update=(action "updateSelection" option)
           disabled=disabled
           dir=dir

--- a/addon/templates/components/form-fields/custom-field.hbs
+++ b/addon/templates/components/form-fields/custom-field.hbs
@@ -10,6 +10,7 @@
     hint=hint
     label=label
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{#if component}}
     {{component component f=f}}

--- a/addon/templates/components/form-fields/radio-field.hbs
+++ b/addon/templates/components/form-fields/radio-field.hbs
@@ -10,6 +10,7 @@
     form=form
     label=labelText
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{#f.label required=required}}
     {{f.control

--- a/addon/templates/components/form-fields/radio-group.hbs
+++ b/addon/templates/components/form-fields/radio-group.hbs
@@ -18,6 +18,7 @@
           disabled=disabled
           tagName="li"
           object=object
+          focusIn=fieldFocusIn
           update=(action update)
       }}
     {{/each}}

--- a/addon/templates/components/form-fields/select-field.hbs
+++ b/addon/templates/components/form-fields/select-field.hbs
@@ -10,6 +10,7 @@
     form=form
     label=label
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{f.label required=required}}
   {{f.control

--- a/addon/templates/components/form-fields/text-field.hbs
+++ b/addon/templates/components/form-fields/text-field.hbs
@@ -12,6 +12,7 @@
     form=form
     label=label
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{f.label required=required}}
   {{f.control

--- a/addon/templates/components/form-fields/textarea-field.hbs
+++ b/addon/templates/components/form-fields/textarea-field.hbs
@@ -10,6 +10,7 @@
     form=form
     label=label
     control=control
+    focusIn=fieldFocusIn
     update=(action update) as |f|}}
   {{f.label required=required}}
   {{f.control


### PR DESCRIPTION
I would like to react to various actions in form fields. In this PR, I have just added a focusIn but idea is very same as with PR#181. The problem is that name of the parameter should match the original name what is not a case because of an assertion. If anyone knows how to fix that, I can prepare full patch with tests. 