### PR TITLE
Fixed initializer name

### DIFF
--- a/app/initializers/ember-form-for-i18n.js
+++ b/app/initializers/ember-form-for-i18n.js
@@ -6,7 +6,7 @@ export function initialize(app) {
 }
 
 export default {
-  name: 'i18n',
+  name: 'ember-form-for-i18n',
   initialize: initialize,
 };
 


### PR DESCRIPTION
The previous name conflicts with https://github.com/kellyselden/ember-i18n-inject/blob/master/addon/initializers/i18n.js#L16, making it impossible to use `ember-form-for` together with `ember-i18n-inject`.