### PR TITLE
Enabling form-for to be used in engines

### DIFF
--- a/app/initializers/ember-form-for-i18n.js
+++ b/app/initializers/ember-form-for-i18n.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
+
 export function initialize(app) {
-  let i18n = app.__container__.lookup('service:i18n');
+  let owner = app.__container__ || Ember.getOwner(app);
+  let i18n = owner.lookup('service:i18n');
   if (i18n) {
     app.inject('component', 'i18n', 'service:i18n');
   }

--- a/blueprints/ember-form-for/index.js
+++ b/blueprints/ember-form-for/index.js
@@ -1,0 +1,21 @@
+var VersionChecker = require('ember-cli-version-checker');
+
+module.exports = {
+
+  name: 'ember-form-for',
+
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    var addon = this;
+    var checker = new VersionChecker(addon);
+    var addonPackages = [];
+
+    if (checker.for('ember', 'bower').satisfies('>= 2.3')) {
+      addonPackages.push({name: 'ember-getowner-polyfill', target: '^2.0.1'});
+
+      return addon.addAddonsToProject({ packages: addonPackages });
+    }
+
+  }
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ember-async-button": "1.0.2",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-invoke-action": "1.4.0",
     "ember-one-way-controls": "^2.0.0",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,6 +2590,13 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 "ember-cli-yuidoc@ 0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/ember-cli-yuidoc/-/ember-cli-yuidoc-0.8.4.tgz#f68a669e750bf89b105bdbbc0360188d3f221a83"


### PR DESCRIPTION
Tried to use ember-form-for in an in-repo engine, the initializer crashed with `app.__container__ is undefined`.

I'm not sure if this fix is the right approach.