### PR TITLE
Add support for Ember Engines

### DIFF
--- a/app/initializers/ember-form-for-i18n.js
+++ b/app/initializers/ember-form-for-i18n.js
@@ -1,5 +1,14 @@
+import Ember from 'ember';
+
 export function initialize(app) {
-  let i18n = app.__container__.lookup('service:i18n');
+  let i18n = null;
+
+  try {
+    i18n = Ember.getOwner(app).lookup('service:i18n');
+  } catch (e) {
+    i18n = app.__container__.lookup('service:i18n');
+  }
+
   if (i18n) {
     app.inject('component', 'i18n', 'service:i18n');
   }


### PR DESCRIPTION
When using ember-form-for inside an engine I currently get the follow tracebacks:

```
TypeError: Cannot read property 'lookup' of undefined
    at Object.initialize (ember-form-for-i18n.js:9)
    at engine.js:88
    at Vertices.each (dag-map.js:188)
    at Vertices.walk (dag-map.js:117)
    at DAG.each (dag-map.js:62)
    at DAG.topsort (dag-map.js:68)
    at Class._runInitializer (engine.js:110)
    at Class.runInitializers (engine.js:75)
    at Class.ensureInitializers (engine.js:50)
    at Class.buildInstance (engine.js:57)
defaultDispatch @ ember-metal.js:3927
dispatchError @ ember-metal.js:3908
onerrorDefault @ rsvp.js:23
trigger @ rsvp.js:85
(anonymous) @ rsvp.js:928
invoke @ backburner.js:274
flush @ backburner.js:153
flush @ backburner.js:345
end @ backburner.js:455
Backburner._boundAutorunEnd @ backburner.js:417
setTimeout (async)
Backburner.platform.next @ backburner.js:405
_ensureInstance @ backburner.js:947
schedule @ backburner.js:606
(anonymous) @ rsvp.js:13
fulfill @ rsvp.js:345
handleMaybeThenable @ rsvp.js:310
resolve @ rsvp.js:318
resolved @ rsvp.js:458
ember-metal.js:3927 TypeError: Cannot read property 'router' of undefined
    at error (router.js:851)
    at Router$1.triggerEvent (router.js:1036)
    at trigger (router.js:111)
    at Transition.trigger (router.js:645)
    at router.js:456
    at tryCatch (rsvp.js:411)
    at invokeCallback (rsvp.js:424)
    at publish (rsvp.js:394)
    at publishRejection (rsvp.js:329)
    at rsvp.js:14
```

This pull request fixes this issue because it no longer tries to use the `lookup` on the `__container__` (which is `null` in an engine).