### PR TITLE
Helper for acceptance-test to locate elements in the form

### DIFF
--- a/test-support/helpers/form-for-element-find.js
+++ b/test-support/helpers/form-for-element-find.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export function formForElementFind(labelText) {
+  let result;
+
+  find('label.form-field--label').each((idx, label) => {
+    if (label.innerText.trim().toLowerCase() === labelText.toLowerCase()) {
+      result = label.nextElementSibling;
+    }
+  });
+
+  return result;
+}
+
+export default formForElementFind;


### PR DESCRIPTION
In the acceptance tests, it is very useful to detect form fields using the labels as they
order might change.

Usage: fillIn(formForElementFind("firstname"), "foo");