### PR TITLE
replace deprecated ember-async-button

### DIFF
--- a/addon/components/form-controls/button.js
+++ b/addon/components/form-controls/button.js
@@ -20,6 +20,7 @@ const Button = Component.extend(DynamicAttributeBindings, {
 
     let type = get(this, 'type');
     let buttonClasses = get(this, `config.${type}Classes`);
+    // @todo: this is bad practice, it should be fixed
     let classNames = get(this, 'classNames');
     set(this, 'classNames', (classNames || []).concat(buttonClasses));
   }

--- a/addon/components/form-controls/reset.js
+++ b/addon/components/form-controls/reset.js
@@ -1,12 +1,12 @@
 import ButtonComponent from './button';
 
-import { invokeAction } from 'ember-invoke-action';
-
 export default ButtonComponent.extend({
   type: 'reset',
 
-  click(e) {
+  click(e, ...args) {
     e.preventDefault();
-    invokeAction(this, 'reset', ...arguments);
+    if (this.get('reset') !== undefined) {
+      this.get('reset')(...args);
+    }
   }
 });

--- a/addon/components/form-controls/submit.js
+++ b/addon/components/form-controls/submit.js
@@ -1,14 +1,19 @@
 import Ember from 'ember';
-import AsyncButton from 'ember-async-button/components/async-button';
-import layout from 'ember-async-button/templates/components/async-button';
-import DynamicAttributeBindings from 'ember-one-way-controls/-private/dynamic-attribute-bindings';
+import Button from './button';
+import layout from 'ember-form-for/templates/components/form-controls/submit';
 
-const { get, set, inject: { service }, computed: { alias } } = Ember;
+const { computed: { alias }, PromiseProxyMixin, Object, RSVP, computed } = Ember;
 
-const SubmitButton = AsyncButton.extend(DynamicAttributeBindings, {
+const SubmitButton = Button.extend({
   layout,
+  tagName: 'button',
+  type: 'submit',
 
-  config: service('ember-form-for/config'),
+  activePromise: undefined,
+
+  classNames: ['async-button'],
+  attributeBindings: ['disabled', 'type'],
+
   submit: alias('action'),
   default: 'Submit',
   pending: 'Submitting...',
@@ -19,12 +24,27 @@ const SubmitButton = AsyncButton.extend(DynamicAttributeBindings, {
 
   init() {
     this._super(...arguments);
+  },
 
-    let type = get(this, 'type');
-    let buttonClasses = get(this, `config.${type}Classes`);
-    let classNames = get(this, 'classNames');
-    set(this, 'classNames', (classNames || []).concat(buttonClasses));
-  }
+  click() {
+    // PromiseProxyMixin allows us to use .isPending in the templates
+    // RSVP.Promise is required to handle situation when submit function
+    // returns non-promise.
+    this.set('activePromise', Object.extend(PromiseProxyMixin).create({
+      promise: new RSVP.Promise((resolve) => {
+        resolve(this.get('submit')());
+      })
+    }));
+    return false;
+  },
+
+  disabled: computed('activePromise.isPending', function() {
+    if (this.get('activePromise.isPending') === true) {
+      return true;
+    } else {
+      return false;
+    }
+  })
 });
 
 SubmitButton.reopenClass({

--- a/addon/components/form-fields/checkbox-group.js
+++ b/addon/components/form-fields/checkbox-group.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../../templates/components/form-fields/checkbox-group';
-import { invokeAction } from 'ember-invoke-action';
 
 const {
   Component,
@@ -20,7 +19,9 @@ const CheckboxGroupComponent = Component.extend({
         selection.removeObject(value);
       }
 
-      invokeAction(this, 'update', object, propertyName, selection);
+      if (this.get('update') !== undefined) {
+        this.get('update')(object, propertyName, selection);
+      }
     }
   }
 });

--- a/addon/templates/components/form-controls/submit.hbs
+++ b/addon/templates/components/form-controls/submit.hbs
@@ -1,0 +1,9 @@
+{{#if hasBlock}}
+  {{yield this _stateObject}}
+{{else}}
+  {{#if activePromise.isPending}}
+    {{pending}}
+  {{else}}
+    {{default}}
+  {{/if}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
-    "ember-invoke-action": "1.4.0",
     "ember-one-way-controls": "https://github.com/marxsk/ember-one-way-controls.git",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-async-button": "1.0.2",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-invoke-action": "1.4.0",

--- a/tests/integration/components/form-controls/submit-test.js
+++ b/tests/integration/components/form-controls/submit-test.js
@@ -29,7 +29,7 @@ test('Clicking the submit button triggers the "action" action', function(assert)
 });
 
 test('Clicking the submit button supports returning a promise', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   let promise = new RSVP.Promise((resolve) => {
     run.later(this, () => {
       resolve();
@@ -44,6 +44,7 @@ test('Clicking the submit button supports returning a promise', function(assert)
 
   $button.trigger('click');
   assert.equal($button.text().trim(), 'Submitting...', 'Button state changes on pending promise');
+  assert.equal(true, $button[0].disabled, 'Button should be disabled when promise is pending');
 
   return wait().then(() => {
     promise.then(() => {


### PR DESCRIPTION
Replaces ember-async-button by extending existing button component. It is possible that we will need more tests to fully test transition. 