### PR TITLE
[break-backward-compatibility] Access to the promise in the form-controls/submit

### DIFF
--- a/addon/templates/components/form-controls/submit.hbs
+++ b/addon/templates/components/form-controls/submit.hbs
@@ -1,5 +1,5 @@
 {{#if hasBlock}}
-  {{yield this _stateObject}}
+  {{yield this activePromise}}
 {{else}}
   {{#if activePromise.isPending}}
     {{pending}}

--- a/tests/integration/components/form-controls/submit-test.js
+++ b/tests/integration/components/form-controls/submit-test.js
@@ -14,6 +14,16 @@ test('It renders a submit button', function(assert) {
   assert.equal(this.$('button').attr('type'), 'submit', 'Submit button is rendered');
 });
 
+test('It renders a user-defined submit button', function(assert) {
+  this.render(hbs`
+    {{#form-controls/submit}}
+      foo
+    {{/form-controls/submit}}
+  `);
+
+  assert.equal(this.$('button').text().trim(), 'foo', 'Submit button shows user defined label');
+});
+
 test('Clicking the submit button triggers the "submit" action', function(assert) {
   assert.expect(1);
   this.on('submit', () => assert.ok(true));
@@ -50,6 +60,35 @@ test('Clicking the submit button supports returning a promise', function(assert)
     promise.then(() => {
       assert.ok(true);
       assert.equal($button.text().trim(), 'Submit', 'Button state returns on fulfilled promise');
+    });
+  });
+});
+
+test('Clicking the submit button supports returning a promise and changes user-defined content', function(assert) {
+  assert.expect(3);
+  let promise = new RSVP.Promise((resolve) => {
+    run.later(this, () => {
+      resolve();
+    }, 500);
+  });
+
+  this.on('submit', () => {
+    return promise;
+  });
+  this.render(hbs`
+    {{#form-controls/submit action=(action 'submit') as |t promise|}}
+      {{promise.isPending}}--{{promise.isFulfilled}}--{{promise.isSettled}}--{{promise.isRejected}}
+    {{/form-controls/submit}}
+  `);
+  let $button = this.$('button');
+
+  $button.trigger('click');
+  assert.equal($button.text().trim(), 'true--false--false--false', 'Button state changes on pending promise');
+
+  return wait().then(() => {
+    promise.then(() => {
+      assert.ok(true);
+      assert.equal($button.text().trim(), 'false--true--true--false', 'Button state returns on fulfilled promise');
     });
   });
 });


### PR DESCRIPTION
Previously, developers were able to access state of the promise (string) in ember-async-button.
After it was replaced, it was no longer possible. This breaks a compatibility as promise is returned
instead of the string.

Thanks to @stephankaag for finding this bug.