### PR TITLE
Fix Ember 3.7+ incompatibility

### DIFF
--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -26,7 +26,7 @@ const FormForComponent = Component.extend({
     let classNames = get(this, 'classNames');
     set(this, 'classNames', (classNames || []).concat(formClasses));
 
-    this.propertyDidChange();
+    this.notifyPropertyChange();
   },
 
   submit: (object) => object.save(),


### PR DESCRIPTION
Replaces the long deprecated and now removed `propertyDidChange()` with `notifyPropertyChange()` to fix the Ember 3.7 incompatibility.