### PR TITLE
Replace deprecated Ember.merge with Ember.assign

### DIFF
--- a/app/instance-initializers/form-for-initializer.js
+++ b/app/instance-initializers/form-for-initializer.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
-const { merge, set } = Ember;
+const { assign, set } = Ember;
 
 const DEFAULT_CONFIG = {
   buttonClasses: ['form-button'],
@@ -16,7 +16,7 @@ const DEFAULT_CONFIG = {
 };
 
 export function initialize(application) {
-  let formForConfig = merge(DEFAULT_CONFIG, config['ember-form-for']);
+  let formForConfig = assign({}, DEFAULT_CONFIG, config['ember-form-for']);
   let configService = application.lookup('service:ember-form-for/config');
 
   Object.keys(formForConfig).forEach((key) => {


### PR DESCRIPTION
Ember 3.9 produces the following warning from `Ember.merge`:

```
WARN: DEPRECATION: Use of `merge` has been deprecated. Please use `assign` instead. [deprecation id: ember-polyfills.deprecate-merge] See https://emberjs.com/deprecations/v3.x/#toc_ember-polyfills-deprecate-merge for more details.
                    at logDeprecationStackTrace (http://localhost:7357/ui/assets/vendor.js:36708:23)
                    at HANDLERS.(anonymous function) (http://localhost:7357/ui/assets/vendor.js:36802:11)
                    at raiseOnDeprecation (http://localhost:7357/ui/assets/vendor.js:36735:11)
                    at HANDLERS.(anonymous function) (http://localhost:7357/ui/assets/vendor.js:36802:11)
                    at invoke (http://localhost:7357/ui/assets/vendor.js:36814:11)
                    at deprecate (http://localhost:7357/ui/assets/vendor.js:36773:30)
                    at merge (http://localhost:7357/ui/assets/vendor.js:41147:44)
                    at Object.initialize (http://localhost:7357/ui/assets/capturama.js:1587:25)
                    at http://localhost:7357/ui/assets/vendor.js:37114:21
```

This replaces it with `Ember.assign()`. One other minor thing, `DEFAULT_CONFIG` is a `const` and `merge`/`assign` mutate it, possibly unexpectedly. It likely doesn't make any difference in this case, but this assigns the value onto `{}` to keep from mutating `DEFAULT_CONFIG`.