### PR TITLE
Validate form before calling submit action

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     'plugin:ember-suave/recommended'
   ],
   env: {
-    'browser': true
+    'browser': true,
+    'es6': true
   },
   rules: {
   }

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ update the property on the object with the new value.
 
 This action is called when a submit button is clicked. It will pass the object
 as first argument. By default it will call the `save` function on the object.
-This action also supports returning a promise, which the `{{f.submit}}` component,
-which uses [ember-async-button], will handle to show different states.
+This action also supports returning a promise, which the `{{f.submit}}` component.
 
 #### reset
 
@@ -184,7 +183,7 @@ Additionally these buttons are also available:
 
  - button
  - reset
- - submit (uses [ember-async-button] so supports those options as well).
+ - submit
 
 ## form-fields
 
@@ -287,4 +286,3 @@ while Ember Form For expects them (by default) to be on the `errors` property.
 For those still using the old configuration of setting `errorsProperty`, this method will still work.
 However, if both are defined then `errorsPath` will take precedence.
 
-[ember-async-button]: https://github.com/DockYard/ember-async-button

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -21,7 +21,8 @@ const FormForComponent = Component.extend({
 
   config: service('ember-form-for/config'),
 
-  attributeBindings: ['tabindex', 'form:id'],
+  attributeBindings: ['tabindex', 'form:id', 'novalidate'],
+  novalidate: false,
 
   init() {
     this._super(...arguments);
@@ -94,12 +95,15 @@ const FormForComponent = Component.extend({
 
   actions: {
     submit(object) {
-      this.__isFormValid(object).then((isValid) => {
-        if (isValid === false) {
-          return isChangeset(object) ? null : this.element.reportValidity();
-        }
-        return this.__submit(object);
-      });
+      if (get(this, 'novalidate') === false) {
+        return this.__isFormValid(object).then((isValid) => {
+          if (isValid === false) {
+            return isChangeset(object) ? null : this.element.reportValidity();
+          }
+          return this.__submit(object);
+        });
+      }
+      return this.__submit(object);
     }
   }
 });

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -10,6 +10,10 @@ const {
   set
 } = Ember;
 
+const isChangeset = function(object) {
+  return get(object, '_content') !== undefined;
+};
+
 const FormForComponent = Component.extend({
   layout,
 
@@ -55,24 +59,47 @@ const FormForComponent = Component.extend({
     }
   },
 
+  __isFormValid(object) {
+    let promise = new Promise((resolve) => {
+
+      let _isChangeset = isChangeset(object);
+
+      if (_isChangeset) {
+        object.validate()
+          .then(() => resolve(get(object, 'isValid')));
+      }
+      return resolve(this.element.checkValidity());
+    });
+    return promise;
+  },
+
+  __submit(object) {
+    let promise = get(this, 'submit')(object);
+
+    set(this, 'tabindex', undefined);
+
+    if (promise && typeof promise.finally === 'function') {
+      promise.finally(() => {
+        if (this.isDestroyed || this.isDestroying) {
+          return;
+        }
+        this.handleErrors(object);
+      });
+    } else {
+      this.handleErrors(object);
+    }
+
+    return promise;
+  },
+
   actions: {
     submit(object) {
-      let promise = get(this, 'submit')(object);
-
-      set(this, 'tabindex', undefined);
-
-      if (promise && typeof promise.finally === 'function') {
-        promise.finally(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return;
-          }
-          this.handleErrors(object);
-        });
-      } else {
-        this.handleErrors(object);
-      }
-
-      return promise;
+      this.__isFormValid(object).then((isValid) => {
+        if (isValid === false) {
+          return isChangeset(object) ? null : this.element.reportValidity();
+        }
+        return this.__submit(object);
+      });
     }
   }
 });

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -171,7 +171,7 @@ test('Form is focused when submit action is triggered and object contains errors
   });
 
   this.render(hbs`
-    {{#form-for object as |f|}}
+    {{#form-for object novalidate=true as |f|}}
       {{f.submit}}
     {{/form-for}}
   `);

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -216,3 +216,18 @@ test('it should not call the submit action if the form is not valid', function(a
   this.$('button[type="submit"]').click();
   assert.ok(true);
 });
+
+test('it should call the submit action if novalidate is set (even if the form is not valid)', function(assert) {
+  assert.expect(1);
+  this.on('submit', () => {
+    assert.ok(true);
+  });
+  this.render(hbs`
+    {{#form-for object novalidate=true submit=(action 'submit') as |f|}}
+      {{f.text-field "lastname" required=true}}
+      {{f.submit}}
+    {{/form-for}}
+  `);
+
+  this.$('button[type="submit"]').click();
+});

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -201,3 +201,18 @@ test('It passes down the form attribute to fields', function(assert) {
 
   assert.equal(this.$('form input').attr('name'), 'user[name]');
 });
+
+test('it should not call the submit action if the form is not valid', function(assert) {
+  this.on('submit', () => {
+    throw new Error('"submit" action should not be called');
+  });
+  this.render(hbs`
+    {{#form-for object submit=(action 'submit') as |f|}}
+      {{f.text-field "lastname" required=true}}
+      {{f.submit}}
+    {{/form-for}}
+  `);
+
+  this.$('button[type="submit"]').click();
+  assert.ok(true);
+});


### PR DESCRIPTION
This is a fix for #232 

Currently ember-form-for does not prevent the submission of invalid forms.